### PR TITLE
Remove volume mount from app service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,6 @@ services:
     tty: true
     environment:
       SERVICE_NAME: app
-    volumes:
-      - ./:/var/www
-      - ./services/php/local.ini:/usr/local/etc/php/conf.d/local.ini
     networks:
       - default
     depends_on:


### PR DESCRIPTION
The coordinape-backend Dockerfile runs the command `COPY --chown=www:www . /var/www` which copies all of the source files into the docker image. Mounting the source directory is therefore unnecessary (I think?) and leads to permissions issues with docker-compose.

Not clear to me if this will effect dev workflows. Hot reload won't work anymore, but that feels okay for a backend service