### PR TITLE
Get dockerized backend serving on linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,12 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN docker-php-ext-install pcntl gmp pdo pdo_pgsql pgsql
 
-RUN groupadd -g 1000 www
-RUN useradd -u 1000 -g www -ms /bin/bash www
-
-COPY --chown=www:www . /var/www
-RUN chown www:www /var/www
+COPY . /var/www
+RUN chown -R www-data:www-data /var/www
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-USER www
+USER www-data
 
 RUN composer install
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       DB_USERNAME: postgres
       DB_PASSWORD: postgrespassword
     volumes:
-      - ./:/var/www
+      - www-volume:/var/www
       - ./services/php/local.ini:/usr/local/etc/php/conf.d/local.ini
     networks:
       - default
@@ -42,7 +42,7 @@ services:
       - "9000:80"
       - "443:443"
     volumes:
-      - ./:/var/www
+      - www-volume:/var/www
       - ./services/nginx/conf.d/:/etc/nginx/conf.d/
     networks:
       - default
@@ -54,3 +54,4 @@ networks:
     driver: bridge
 volumes:
   db_data: null
+  www-volume: null


### PR DESCRIPTION
In my attempts to get the dockerized backend up and running on my linux
machine, I encountered this issue where nginx did not have access to the
shared volume files. It turns out that volumes exposed from a linux host
machine's file system abide by the host system's ACL.

I've resolved this issue by first copying the web server files into the
app container, changing the permissions as needed, and then creating a
volume that is only shared between the nginx and app containers. This
way, the containers control the file system ACL and the host filesystem
is out of the way.

This potentially complicates processes involving bumping dependencies
but otherwise seems like a pretty clean solution, since we don't need to
modify the nginx image at all.

Definitely let me know if I've broken a dependency
management workflow, or any other workflow for that matter, in which
case the nginx image user can be modified to work nicely with the host.

test plan:

1. follow the setup instructions in the markdown file
2. request http://localhost:9000 once the containers are all up
3. Observe the behavior matches that of the staging endpoint when
   queried: https://staging-api.coordinape.com/api