### PR TITLE
Get dockerized backend serving on linux: DevX Friendly version

### DIFF
--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -1,0 +1,16 @@
+FROM nginx:1.21.5
+
+# Customization of the nginx user and group ids in the image. It's 101:101 in
+# the base image. Here we use 1000 which is the user id and group id for
+# the first-created user on most linux and macOS machines. This can be
+# overridden in the docker-compose file or `$ docker build` if needed.
+ARG nginx_uid=1000
+ARG nginx_gid=1000
+
+# The worker processes in the nginx image run as the user nginx with group
+# nginx. This is where we override their respective uid and guid to something
+# else that lines up better with file permissions.
+# The -o switch allows reusing an existing user id
+RUN usermod -u $nginx_uid -o nginx && groupmod -g $nginx_gid -o nginx
+
+# vim: ft=dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,12 @@ services:
 
   nginx:
     container_name: nginx
-    image: nginx
+    build:
+      dockerfile: Dockerfile-nginx
+      args:
+        # override the defaults in the dockerfile here
+        nginx_uid: 1000
+        nginx_gid: 1000
     restart: unless-stopped
     tty: true
     ports:


### PR DESCRIPTION
In my attempts to get the dockerized backend up and running on my linux
machine, I encountered this issue where nginx did not have access to the
shared volume files. It turns out that volumes exposed from a linux host
machine's file system force containers to abide by the host system's ACL.

In an effort to preserve hot-reload functionality while running this
suite of containers, I've left the host-exposed docker volume setup
as-is and instead updated the nginx container to have the same UID and
GID for the nginx user as the host file system. These IDs can now be
modified inside the docker-compose file if needed as well.

test plan:

1. follow the setup instructions in the markdown file
2. request http://localhost:9000 once the containers are all up
3. Observe the behavior matches that of the staging endpoint when
   queried: https://staging-api.coordinape.com/api