### PR TITLE
chore #77 - raising nginx client_max_body_size to 5M

### DIFF
--- a/services/nginx/conf.d/app.conf
+++ b/services/nginx/conf.d/app.conf
@@ -1,3 +1,5 @@
+client_max_body_size 5M;
+
 server {
     listen 80;
     index index.php index.html;


### PR DESCRIPTION
#77 This allows for larger avatar/background uploads , see https://github.com/coordinape/coordinape/issues/390 in the frontend.