### PR TITLE
adding GD dependencies to apt-get for image processing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,12 @@ RUN apt-get update && apt-get install -y \
   zip \
   git \
   curl \
-  libpq-dev
+  libpq-dev \
+  libpng-dev \
+  libjpeg62-turbo-dev \
+  && docker-php-ext-configure gd --with-jpeg \
+  && docker-php-ext-install -j$(nproc) gd
+
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
   nginx:
     container_name: nginx
     build:
+      context: .
       dockerfile: Dockerfile-nginx
       args:
         # override the defaults in the dockerfile here


### PR DESCRIPTION
This is required for uploading avatars and doing resizing. Fixes #79 